### PR TITLE
 feat: Add Apple Silicon (MPS) GPU support for macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,20 @@ index-strategy = "unsafe-best-match"
 required-environments = [
     "sys_platform == 'win32' and platform_machine == 'AMD64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 override-dependencies = [
-    "nvidia-nccl-cu12; sys_platform != 'win32'",
+    "nvidia-nccl-cu12; sys_platform == 'linux'",
 ]
 
 [[tool.uv.index]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
 
 [project]
 name = "VieNeu-TTS"
@@ -20,24 +26,39 @@ readme = "README.md"
 requires-python = "==3.12.*"
 dependencies = [
     "phonemizer>=3.3.0",
-    "torch",
-    "torchvision",
-    "torchaudio",
     "neucodec>=0.0.4",
     "librosa>=0.11.0",
     "gradio>=5.49.1",
     "onnxruntime>=1.23.2",
     "datasets>=3.2.0",
-    "lmdeploy",
+    "lmdeploy; sys_platform != 'darwin'",
     "triton-windows; sys_platform == 'win32'",
-    "triton; sys_platform != 'win32'",
+    "triton; sys_platform == 'linux'",
+    "transformers; sys_platform == 'darwin'",
+    "accelerate; sys_platform == 'darwin'",
+    
+    "torch",
+    "torchvision",
+    "torchaudio",
 ]
 
 [tool.uv.sources]
-torch = { index = "pytorch" }
-torchvision = { index = "pytorch" }
-torchaudio = { index = "pytorch" }
+
+torch = [
+    { index = "pytorch", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" } 
+]
+torchvision = [
+    { index = "pytorch", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" }
+]
+torchaudio = [
+    { index = "pytorch", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" }
+]
+
 lmdeploy = [
     { url = "https://github.com/InternLM/lmdeploy/releases/download/v0.11.0/lmdeploy-0.11.0+cu128-cp312-cp312-win_amd64.whl", marker = "sys_platform == 'win32' and python_version == '3.12'" },
     { url = "https://github.com/InternLM/lmdeploy/releases/download/v0.11.0/lmdeploy-0.11.0+cu128-cp312-cp312-manylinux2014_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.12'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" }
 ]

--- a/pyproject.toml.cpu
+++ b/pyproject.toml.cpu
@@ -1,24 +1,24 @@
-
 [tool.uv]
 index-strategy = "unsafe-best-match"
 required-environments = [
     "sys_platform == 'win32' and platform_machine == 'AMD64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
 
 [[tool.uv.index]]
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
-[tool.uv.sources]
-torch = { index = "pytorch-cpu" }
-torchaudio = { index = "pytorch-cpu" }
-llama-cpp-python = { index = "llama-cpp-python-whl", marker = "sys_platform == 'win32'" }
-
 [[tool.uv.index]]
 name = "llama-cpp-python-whl"
 url = "https://abetlen.github.io/llama-cpp-python/whl/cpu"
+explicit = true
 
 [project]
 name = "VieNeu-TTS"
@@ -36,4 +36,18 @@ dependencies = [
     "onnxruntime>=1.23.2",
     "datasets>=3.2.0",
     "llama-cpp-python>=0.3.2",
+]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" }
+]
+torchaudio = [
+    { index = "pytorch-cpu", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" }
+]
+llama-cpp-python = [
+    { index = "llama-cpp-python-whl", marker = "sys_platform == 'win32'" },
+    { index = "pypi", marker = "sys_platform != 'win32'" }
 ]

--- a/vieneu_tts/vieneu_tts.py
+++ b/vieneu_tts/vieneu_tts.py
@@ -122,6 +122,12 @@ class VieNeuTTS:
         self._load_codec(codec_repo, codec_device)
     
     def _load_backbone(self, backbone_repo, backbone_device):
+        # MPS device validation
+        if backbone_device == "mps":
+            if not torch.backends.mps.is_available():
+                print("Warning: MPS not available, falling back to CPU")
+                backbone_device = "cpu"
+
         print(f"Loading backbone from: {backbone_repo} on {backbone_device} ...")
 
         if backbone_repo.lower().endswith("gguf") or "gguf" in backbone_repo.lower():
@@ -151,6 +157,12 @@ class VieNeuTTS:
             )
     
     def _load_codec(self, codec_repo, codec_device):
+        # MPS device validation
+        if codec_device == "mps":
+            if not torch.backends.mps.is_available():
+                print("Warning: MPS not available for codec, falling back to CPU")
+                codec_device = "cpu"
+
         print(f"Loading codec from: {codec_repo} on {codec_device} ...")
         match codec_repo:
             case "neuphonic/neucodec":


### PR DESCRIPTION
## Summary

Add native Apple Silicon GPU support for VieNeu-TTS on macOS using PyTorch MPS backend.

### Changes:
- Add MPS device detection and validation in `vieneu_tts.py`
- Update `gradio_app.py` with platform-aware device selection
- Dynamic UI device options based on platform (MPS on Mac, CUDA on Windows/Linux)
- Add MPS memory cleanup support

### Platform behavior:

| Platform | Available devices | Backends |
|----------|------------------|----------|
| macOS | Auto, CPU, MPS | VieNeuTTS (PyTorch + MPS), GGUF (Metal) |
| Windows/Linux | Auto, CPU, CUDA | VieNeuTTS, FastVieNeuTTS (LMDeploy) |

### Notes:
- `FastVieNeuTTS` remains CUDA-only (requires lmdeploy)
- GGUF streaming works on Mac via llama-cpp-python with Metal
- ONNX codec remains CPU-only