### PR TITLE
fix: replace bare excepts with specific exception types (6 sites)

### DIFF
--- a/src/vieneu/core.py
+++ b/src/vieneu/core.py
@@ -154,7 +154,7 @@ class VieNeuTTS:
         """Finalizer to ensure resources are released."""
         try:
             self.close()
-        except:
+        except Exception:
             pass
 
     def close(self):
@@ -172,7 +172,7 @@ class VieNeuTTS:
                         close_fn = getattr(self.backbone, "close", None)
                         if callable(close_fn):
                             close_fn()
-                    except:
+                    except Exception:
                         pass
                 self.backbone = None
             
@@ -188,7 +188,7 @@ class VieNeuTTS:
                     if callable(getattr(_torch.cuda, "is_available", None)) and _torch.cuda.is_available():
                         if callable(getattr(_torch.cuda, "empty_cache", None)):
                             _torch.cuda.empty_cache()
-        except:
+        except Exception:
             # Silence all exit errors as we are shutting down anyway
             pass
 

--- a/src/vieneu/core_xpu.py
+++ b/src/vieneu/core_xpu.py
@@ -131,7 +131,7 @@ class XPUVieNeuTTS(VieNeuTTS):
         try:
             if hasattr(torch, 'xpu') and torch.xpu.is_available():
                 torch.xpu.empty_cache()
-        except:
+        except Exception:
             pass
     
     def infer_batch(

--- a/src/vieneu/serve.py
+++ b/src/vieneu/serve.py
@@ -15,7 +15,7 @@ def check_command(cmd):
 def get_public_ip():
     try:
         return requests.get("https://api.ipify.org").text
-    except:
+    except Exception:
         return "your-server-ip"
 
 def run_server(args):

--- a/src/vieneu_utils/cleaner/datestime.py
+++ b/src/vieneu_utils/cleaner/datestime.py
@@ -17,7 +17,7 @@ def _is_valid_date(day, month):
     try:
         day, month = int(day), int(month)
         return 1 <= month <= 12 and 1 <= day <= day_in_month[month - 1]
-    except: return False
+    except (ValueError, IndexError): return False
 
 def _expand_full_date(match):
     day, sep1, month, sep2, year = match.groups()


### PR DESCRIPTION
Replace bare `except:` with specific exception types across 5 files (6 sites).

**Changes:**
| File | Exception Type | Reason |
|------|---------------|--------|
| `core.py` (3 sites) | `Exception` | Cleanup/shutdown handlers |
| `core_xpu.py` | `Exception` | XPU cache cleanup |
| `serve.py` | `Exception` | IP lookup fallback |
| `datestime.py` | `(ValueError, IndexError)` | Date string validation |

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, which can mask critical system signals during shutdown. Using specific types preserves the intended fallback behavior.