### PR TITLE
fix: force UTF-8 stdout/stderr on Windows to avoid UnicodeEncodeError

### DIFF
--- a/apps/gradio_main.py
+++ b/apps/gradio_main.py
@@ -1,10 +1,19 @@
+import sys
+import io
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
 import gradio as gr
 print("⏳ Đang khởi động VieNeu-TTS... Vui lòng chờ...")
 import soundfile as sf
 import tempfile
 from vieneu import Vieneu
 import os
-import sys
 import time
 import numpy as np
 import queue


### PR DESCRIPTION
On Windows with non-UTF-8 console code pages (e.g. cp1258 Vietnamese), `print("⏳ Đang khởi động...")` at app startup crashes with UnicodeEncodeError. Reconfigure sys.stdout/sys.stderr to UTF-8 before any print() runs so emoji and Vietnamese diacritics work on default Windows terminals.