### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-suffix: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+          uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Run tests
+        run: uv run pytest -v --tb=short


### PR DESCRIPTION
Add a CI workflow that runs the existing test suite on push/PR to `main`.

- **Platform**: Ubuntu latest
- **Matrix**: Python 3.11, 3.12
- **Deps**: lightweight (CPU) mode via `uv sync --group dev` + CPU-only torch for test imports
- **Cache**: uv cache enabled for faster subsequent runs

Note: 6 tests have pre-existing failures unrelated to this change (mock/assertion issues in `test_engine_standard.py` and `test_engine_remote.py`). These are test bugs, not source bugs.
