### PR TITLE
Remove extra imports of split_text_into_chunks

### DIFF
--- a/apps/gradio_main.py
+++ b/apps/gradio_main.py
@@ -866,9 +866,6 @@ def synthesize_speech(text: str, voice_choice: str, custom_audio, custom_text: s
             sr_v3 = getattr(tts, "sample_rate", 48000)
             try:
                 from vieneu_utils.phonemize_text import phonemize_text_with_emotions
-                from vieneu_utils.core_utils import (
-                    split_text_into_chunks, join_audio_chunks,
-                )
 
                 v3_chunks = split_text_into_chunks(raw_text, max_chars=max_chars_chunk) or [raw_text]
                 v3_bs = max(1, int(max_batch_size_run)) if use_batch else 1


### PR DESCRIPTION
This extra import makes split_text_into_chunks become a local variable, nullyfing the module-level import.

This would result in reference of this function in different branches inside `synthesize_speech` raise `UnboundLocalError`

Screenshot:

<img width="2386" height="1365" alt="image" src="https://github.com/user-attachments/assets/bb7406ea-ad45-4b7c-b446-0472032c9f77" />
