### PR TITLE
feat: support configurable ONNX Runtime providers

### DIFF
--- a/src/vieneu/_v3_turbo_engine/onnx_runtime_lite.py
+++ b/src/vieneu/_v3_turbo_engine/onnx_runtime_lite.py
@@ -72,7 +72,7 @@ class OnnxV3LiteEngine:
         onnx_subfolder: str = "onnx_int8",   # int8 backbone (mặc định); "onnx_update" = fp32
         codec_dir: Optional[str] = None,
         threads: int = 0,
-        providers: Optional[Sequence[str]] = None,
+        providers: Sequence[str] = ("CPUExecutionProvider",),
         **_kw,
     ):
         import onnxruntime as ort
@@ -146,7 +146,7 @@ class OnnxV3LiteEngine:
             intra = min(max((os.cpu_count() or 8) // 2, 1), 8)
         so.intra_op_num_threads = intra
         self.ort_intra_op_threads = intra
-        self.onnx_providers = list(providers or ["CPUExecutionProvider"])
+        self.onnx_providers = list(providers)
         prov = self.onnx_providers
         self.sess_pre = ort.InferenceSession(str(vd / "vieneu_prefill.onnx"), so, providers=prov)
         self.sess_dec = ort.InferenceSession(str(vd / "vieneu_decode_step.onnx"), so, providers=prov)

--- a/src/vieneu/_v3_turbo_engine/onnx_runtime_lite.py
+++ b/src/vieneu/_v3_turbo_engine/onnx_runtime_lite.py
@@ -29,7 +29,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import Generator, List, Optional, Tuple, Union
+from typing import Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -72,6 +72,7 @@ class OnnxV3LiteEngine:
         onnx_subfolder: str = "onnx_int8",   # int8 backbone (mặc định); "onnx_update" = fp32
         codec_dir: Optional[str] = None,
         threads: int = 0,
+        providers: Optional[Sequence[str]] = None,
         **_kw,
     ):
         import onnxruntime as ort
@@ -145,7 +146,8 @@ class OnnxV3LiteEngine:
             intra = min(max((os.cpu_count() or 8) // 2, 1), 8)
         so.intra_op_num_threads = intra
         self.ort_intra_op_threads = intra
-        prov = ["CPUExecutionProvider"]
+        self.onnx_providers = list(providers or ["CPUExecutionProvider"])
+        prov = self.onnx_providers
         self.sess_pre = ort.InferenceSession(str(vd / "vieneu_prefill.onnx"), so, providers=prov)
         self.sess_dec = ort.InferenceSession(str(vd / "vieneu_decode_step.onnx"), so, providers=prov)
         self.sess_ac = ort.InferenceSession(str(vd / "vieneu_acoustic_cached.onnx"), so, providers=prov)
@@ -190,7 +192,7 @@ class OnnxV3LiteEngine:
         try:
             from .onnx_denoiser import OnnxDenoiser
             path = self._resolve_root_file("denoiser.onnx")
-            return OnnxDenoiser(path) if path else None
+            return OnnxDenoiser(path, providers=self.onnx_providers) if path else None
         except Exception:
             return None
 
@@ -209,7 +211,11 @@ class OnnxV3LiteEngine:
         if self.speaker_encoder is None:
             from .speaker import OnnxSpeakerEncoder
             self.speaker_encoder = OnnxSpeakerEncoder.from_pretrained(
-                self.checkpoint_path, filename=self.speaker_encoder_filename, device="cpu")
+                self.checkpoint_path,
+                filename=self.speaker_encoder_filename,
+                device="cpu",
+                providers=self.onnx_providers,
+            )
         return self.speaker_encoder
 
     # ── numpy embedding / speaker anchor / heads / sampling ────────────────────
@@ -554,7 +560,10 @@ class OnnxV3LiteEngine:
         lens = np.array([stereo.shape[-1]], dtype=np.int32)
         if self._sess_codec_enc is None:
             import onnxruntime as ort
-            self._sess_codec_enc = ort.InferenceSession(self._codec_enc_path, providers=["CPUExecutionProvider"])
+            self._sess_codec_enc = ort.InferenceSession(
+                self._codec_enc_path,
+                providers=self.onnx_providers,
+            )
         out = self._sess_codec_enc.run(None, {"waveform": stereo, "input_lengths": lens})
         return np.asarray(out[0][0], dtype=np.int64)               # (T, n_vq)
 

--- a/src/vieneu/turbo.py
+++ b/src/vieneu/turbo.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional, List, Any, Generator, Dict
 from pathlib import Path
 from .base import BaseVieneuTTS
-from .utils import normalize_device
+from .utils import normalize_device, select_onnx_providers
 from vieneu_utils.phonemize_text import phonemize_batch, phonemize_to_chunks
 from vieneu_utils.core_utils import split_into_chunks_v2, get_silence_duration_v2
 from tqdm import tqdm
@@ -16,16 +16,21 @@ logger = logging.getLogger("Vieneu.Turbo")
 class BaseTurboVieNeuTTS(BaseVieneuTTS):
     """Internal base class for Turbo TTS variants to share ONNX and prompt logic."""
 
-    def __init__(self, codec_repo=None, codec_device="cpu"):
+    def __init__(self, codec_repo=None, codec_device="cpu", onnx_providers=None):
         super().__init__(codec_repo=codec_repo, codec_device=codec_device)
         self.decoder_sess = None
         self.encoder_sess = None
         self._is_onnx_codec = True
+        self._onnx_providers = onnx_providers
 
     def _get_onnx_providers(self, device: str) -> list:
-        if device == "cuda":
-            return ["CUDAExecutionProvider", "CPUExecutionProvider"]
-        return ["CPUExecutionProvider"]
+        import onnxruntime as ort
+
+        return select_onnx_providers(
+            ort.get_available_providers(),
+            device=device,
+            requested_providers=self._onnx_providers,
+        )
 
     def _load_decoder(self, decoder_repo, decoder_filename, device, hf_token=None):
         import onnxruntime as ort
@@ -125,17 +130,19 @@ class TurboGPUVieNeuTTS(BaseTurboVieNeuTTS):
         device: str = "cuda",
         backend: str = "standard",
         hf_token: Optional[str] = None,
+        onnx_providers: Optional[List[str]] = None,
         **kwargs
     ):
-        super().__init__()
+        super().__init__(onnx_providers=onnx_providers)
+        self.onnx_device = device
         self.device = normalize_device(device)
         self.backend = backend.lower()
         self.backbone = None
         self.tokenizer = None
 
         self._load_backbone(backbone_repo, self.device, hf_token, **kwargs)
-        self._load_decoder(decoder_repo, decoder_filename, self.device, hf_token)
-        self._load_encoder(encoder_repo, encoder_filename, self.device, hf_token)
+        self._load_decoder(decoder_repo, decoder_filename, self.onnx_device, hf_token)
+        self._load_encoder(encoder_repo, encoder_filename, self.onnx_device, hf_token)
         self._load_voices(backbone_repo, hf_token)
 
     def _load_backbone(self, repo, device, hf_token=None, **kwargs):
@@ -284,14 +291,16 @@ class TurboVieNeuTTS(BaseTurboVieNeuTTS):
         encoder_filename: str = "vieneu_encoder.onnx",
         device: str = "cpu",
         hf_token: Optional[str] = None,
+        onnx_providers: Optional[List[str]] = None,
         **kwargs
     ):
-        super().__init__()
+        super().__init__(onnx_providers=onnx_providers)
+        self.onnx_device = device
         self.device = normalize_device(device)
         self.backbone = None
         self._load_backbone(backbone_repo, backbone_filename, self.device, hf_token, **kwargs)
-        self._load_decoder(decoder_repo, decoder_filename, self.device, hf_token)
-        self._load_encoder(encoder_repo, encoder_filename, self.device, hf_token)
+        self._load_decoder(decoder_repo, decoder_filename, self.onnx_device, hf_token)
+        self._load_encoder(encoder_repo, encoder_filename, self.onnx_device, hf_token)
         self._load_voices(backbone_repo, hf_token)
 
     def _load_backbone(self, backbone_repo, backbone_filename, device, hf_token=None, **kwargs):

--- a/src/vieneu/turbo.py
+++ b/src/vieneu/turbo.py
@@ -4,7 +4,8 @@ import logging
 from typing import Optional, List, Any, Generator, Dict
 from pathlib import Path
 from .base import BaseVieneuTTS
-from .utils import normalize_device, select_onnx_providers
+from .utils import normalize_device
+from vieneu_utils.onnx import select_onnx_providers
 from vieneu_utils.phonemize_text import phonemize_batch, phonemize_to_chunks
 from vieneu_utils.core_utils import split_into_chunks_v2, get_silence_duration_v2
 from tqdm import tqdm

--- a/src/vieneu/utils.py
+++ b/src/vieneu/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import re
 import logging
-from typing import List, Dict, Optional, Any, Sequence
+from typing import List, Dict, Optional, Any
 
 # Configure logging
 logger = logging.getLogger("Vieneu.Utils")
@@ -24,68 +24,6 @@ def normalize_device(device: str) -> str:
         return "xpu"
     return "cpu"
 
-
-def select_onnx_providers(
-    available_providers: Sequence[str],
-    device: str = "cpu",
-    requested_providers: Optional[Sequence[str]] = None,
-) -> List[str]:
-    """Select installed ONNX Runtime providers in deterministic priority order.
-
-    ``requested_providers`` gives callers full control while still failing early
-    when the installed ONNX Runtime package cannot satisfy their request.  With
-    no override, a provider is selected from the requested device and the CPU
-    provider is retained as a fallback when available.
-    """
-    available = list(available_providers)
-    available_set = set(available)
-
-    if requested_providers is not None:
-        requested = list(requested_providers)
-        if not requested:
-            raise ValueError("onnx_providers must contain at least one provider")
-        missing = [provider for provider in requested if provider not in available_set]
-        if missing:
-            raise ValueError(
-                "Requested ONNX Runtime provider(s) are unavailable: "
-                f"{', '.join(missing)}. Available providers: {', '.join(available)}"
-            )
-        return requested
-
-    device_name = str(device or "cpu").lower().split(":", 1)[0]
-    provider_preferences = {
-        "cuda": ["CUDAExecutionProvider"],
-        "gpu": ["CUDAExecutionProvider"],
-        "tensorrt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
-        "trt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
-        "rocm": ["ROCMExecutionProvider", "MIGraphXExecutionProvider"],
-        "amd": ["MIGraphXExecutionProvider", "ROCMExecutionProvider"],
-        "xpu": ["OpenVINOExecutionProvider"],
-        "openvino": ["OpenVINOExecutionProvider"],
-        "mps": ["CoreMLExecutionProvider"],
-        "coreml": ["CoreMLExecutionProvider"],
-        "dml": ["DmlExecutionProvider"],
-        "directml": ["DmlExecutionProvider"],
-        "cpu": ["CPUExecutionProvider"],
-    }
-    selected = [
-        provider
-        for provider in provider_preferences.get(device_name, [])
-        if provider in available_set
-    ]
-    if "CPUExecutionProvider" in available_set and "CPUExecutionProvider" not in selected:
-        selected.append("CPUExecutionProvider")
-    if selected:
-        return selected
-    if available:
-        logger.warning(
-            "No preferred ONNX Runtime provider is available for device '%s'; "
-            "falling back to %s",
-            device,
-            available[0],
-        )
-        return [available[0]]
-    raise RuntimeError("ONNX Runtime reported no available execution providers")
 
 def _linear_overlap_add(frames: List[np.ndarray], stride: int) -> np.ndarray:
     """

--- a/src/vieneu/utils.py
+++ b/src/vieneu/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import re
 import logging
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Sequence
 
 # Configure logging
 logger = logging.getLogger("Vieneu.Utils")
@@ -23,6 +23,69 @@ def normalize_device(device: str) -> str:
     if d == "xpu":
         return "xpu"
     return "cpu"
+
+
+def select_onnx_providers(
+    available_providers: Sequence[str],
+    device: str = "cpu",
+    requested_providers: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Select installed ONNX Runtime providers in deterministic priority order.
+
+    ``requested_providers`` gives callers full control while still failing early
+    when the installed ONNX Runtime package cannot satisfy their request.  With
+    no override, a provider is selected from the requested device and the CPU
+    provider is retained as a fallback when available.
+    """
+    available = list(available_providers)
+    available_set = set(available)
+
+    if requested_providers is not None:
+        requested = list(requested_providers)
+        if not requested:
+            raise ValueError("onnx_providers must contain at least one provider")
+        missing = [provider for provider in requested if provider not in available_set]
+        if missing:
+            raise ValueError(
+                "Requested ONNX Runtime provider(s) are unavailable: "
+                f"{', '.join(missing)}. Available providers: {', '.join(available)}"
+            )
+        return requested
+
+    device_name = str(device or "cpu").lower().split(":", 1)[0]
+    provider_preferences = {
+        "cuda": ["CUDAExecutionProvider"],
+        "gpu": ["CUDAExecutionProvider"],
+        "tensorrt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
+        "trt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
+        "rocm": ["ROCMExecutionProvider", "MIGraphXExecutionProvider"],
+        "amd": ["MIGraphXExecutionProvider", "ROCMExecutionProvider"],
+        "xpu": ["OpenVINOExecutionProvider"],
+        "openvino": ["OpenVINOExecutionProvider"],
+        "mps": ["CoreMLExecutionProvider"],
+        "coreml": ["CoreMLExecutionProvider"],
+        "dml": ["DmlExecutionProvider"],
+        "directml": ["DmlExecutionProvider"],
+        "cpu": ["CPUExecutionProvider"],
+    }
+    selected = [
+        provider
+        for provider in provider_preferences.get(device_name, [])
+        if provider in available_set
+    ]
+    if "CPUExecutionProvider" in available_set and "CPUExecutionProvider" not in selected:
+        selected.append("CPUExecutionProvider")
+    if selected:
+        return selected
+    if available:
+        logger.warning(
+            "No preferred ONNX Runtime provider is available for device '%s'; "
+            "falling back to %s",
+            device,
+            available[0],
+        )
+        return [available[0]]
+    raise RuntimeError("ONNX Runtime reported no available execution providers")
 
 def _linear_overlap_add(frames: List[np.ndarray], stride: int) -> np.ndarray:
     """

--- a/src/vieneu/v3turbo.py
+++ b/src/vieneu/v3turbo.py
@@ -41,12 +41,12 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
         precision: str = "int8",   # ONNX/CPU backbone: "int8" (mặc định, nhanh ~3x/frame, nhỏ 4x) | "fp32" (chất-lượng-tối-đa)
         onnx_subfolder: Optional[str] = None,   # override thủ công subfolder; None → suy từ `precision`
         threads: int = 0,   # ONNX/CPU intra-op threads; 0 = mặc định engine (~nhân vật lý, cap 8). Đặt số cụ thể để tinh chỉnh.
-        onnx_providers: Optional[List[str]] = None,
         max_batch_size: int = 32,   # GPU/PyTorch: trần số chunk gộp vào một forward (static batching). Batch thực = min(số_chunk, max_batch_size). Bỏ qua trên CPU/ONNX.
         **kwargs: Any,
     ):
         super().__init__()
         self.sample_rate = 48_000
+        onnx_providers = kwargs.pop("onnx_providers", None)
 
         # `precision` chỉ áp cho đường ONNX/CPU (chọn subfolder graph int8 vs fp32).
         # Đường PyTorch/GPU dùng torch fp32/bf16, không liên quan.

--- a/src/vieneu/v3turbo.py
+++ b/src/vieneu/v3turbo.py
@@ -20,6 +20,7 @@ from vieneu_utils.phonemize_text import (
     normalize_to_chunks_v3_with_gaps,
 )
 from vieneu_utils.core_utils import join_audio_chunks, gaps_to_silence
+from vieneu_utils.onnx import select_onnx_providers
 
 logger = logging.getLogger("Vieneu.V3Turbo")
 
@@ -40,6 +41,7 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
         precision: str = "int8",   # ONNX/CPU backbone: "int8" (mặc định, nhanh ~3x/frame, nhỏ 4x) | "fp32" (chất-lượng-tối-đa)
         onnx_subfolder: Optional[str] = None,   # override thủ công subfolder; None → suy từ `precision`
         threads: int = 0,   # ONNX/CPU intra-op threads; 0 = mặc định engine (~nhân vật lý, cap 8). Đặt số cụ thể để tinh chỉnh.
+        onnx_providers: Optional[List[str]] = None,
         max_batch_size: int = 32,   # GPU/PyTorch: trần số chunk gộp vào một forward (static batching). Batch thực = min(số_chunk, max_batch_size). Bỏ qua trên CPU/ONNX.
         **kwargs: Any,
     ):
@@ -64,7 +66,14 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
         if use_onnx:
             # Torch-free CPU engine. Reads its ONNX graphs from `onnx_subfolder` in the
             # model repo (uploaded separately).
+            import onnxruntime as ort
             from ._v3_turbo_engine.onnx_runtime_lite import OnnxV3LiteEngine
+
+            selected_providers = select_onnx_providers(
+                ort.get_available_providers(),
+                device=dev_type,
+                requested_providers=onnx_providers,
+            )
             logger.info(f"⏳ Loading VieNeu-TTS v3 Turbo (ONNX/CPU) from: {backbone_repo}/{onnx_subfolder} ...")
             self.engine = OnnxV3LiteEngine(
                 checkpoint_path=backbone_repo,
@@ -72,6 +81,7 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
                 onnx_dir=onnx_dir,
                 onnx_subfolder=onnx_subfolder,
                 threads=threads,
+                providers=selected_providers,
             )
             self.backend = "onnx"
         else:

--- a/src/vieneu_utils/onnx.py
+++ b/src/vieneu_utils/onnx.py
@@ -1,0 +1,67 @@
+import logging
+from typing import List, Optional, Sequence
+
+logger = logging.getLogger("Vieneu.ONNX")
+
+
+def select_onnx_providers(
+    available_providers: Sequence[str],
+    device: str = "cpu",
+    requested_providers: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Select installed ONNX Runtime providers in deterministic priority order.
+
+    ``requested_providers`` gives callers full control while still failing early
+    when the installed ONNX Runtime package cannot satisfy their request. With
+    no override, a provider is selected from the requested device and the CPU
+    provider is retained as a fallback when available.
+    """
+    available = list(available_providers)
+    available_set = set(available)
+
+    if requested_providers is not None:
+        requested = list(requested_providers)
+        if not requested:
+            raise ValueError("onnx_providers must contain at least one provider")
+        missing = [provider for provider in requested if provider not in available_set]
+        if missing:
+            raise ValueError(
+                "Requested ONNX Runtime provider(s) are unavailable: "
+                f"{', '.join(missing)}. Available providers: {', '.join(available)}"
+            )
+        return requested
+
+    device_name = str(device or "cpu").lower().split(":", 1)[0]
+    provider_preferences = {
+        "cuda": ["CUDAExecutionProvider"],
+        "gpu": ["CUDAExecutionProvider"],
+        "tensorrt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
+        "trt": ["TensorrtExecutionProvider", "CUDAExecutionProvider"],
+        "rocm": ["ROCMExecutionProvider", "MIGraphXExecutionProvider"],
+        "amd": ["MIGraphXExecutionProvider", "ROCMExecutionProvider"],
+        "xpu": ["OpenVINOExecutionProvider"],
+        "openvino": ["OpenVINOExecutionProvider"],
+        "mps": ["CoreMLExecutionProvider"],
+        "coreml": ["CoreMLExecutionProvider"],
+        "dml": ["DmlExecutionProvider"],
+        "directml": ["DmlExecutionProvider"],
+        "cpu": ["CPUExecutionProvider"],
+    }
+    selected = [
+        provider
+        for provider in provider_preferences.get(device_name, [])
+        if provider in available_set
+    ]
+    if "CPUExecutionProvider" in available_set and "CPUExecutionProvider" not in selected:
+        selected.append("CPUExecutionProvider")
+    if selected:
+        return selected
+    if available:
+        logger.warning(
+            "No preferred ONNX Runtime provider is available for device '%s'; "
+            "falling back to %s",
+            device,
+            available[0],
+        )
+        return [available[0]]
+    raise RuntimeError("ONNX Runtime reported no available execution providers")

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -8,7 +8,8 @@ sys.modules["torch"] = MagicMock()
 sys.modules["torch.backends"] = MagicMock()
 sys.modules["torch.backends.mps"] = MagicMock()
 
-from vieneu.utils import normalize_device, select_onnx_providers
+from vieneu.utils import normalize_device
+from vieneu_utils.onnx import select_onnx_providers
 from vieneu.base import BaseVieneuTTS
 
 class DummyTTS(BaseVieneuTTS):

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -8,7 +8,7 @@ sys.modules["torch"] = MagicMock()
 sys.modules["torch.backends"] = MagicMock()
 sys.modules["torch.backends.mps"] = MagicMock()
 
-from vieneu.utils import normalize_device
+from vieneu.utils import normalize_device, select_onnx_providers
 from vieneu.base import BaseVieneuTTS
 
 class DummyTTS(BaseVieneuTTS):
@@ -30,6 +30,45 @@ class TestBaseUtils(unittest.TestCase):
             self.assertEqual(normalize_device("mps"), "mps")
         with patch("torch.backends.mps.is_available", return_value=False, create=True):
             self.assertEqual(normalize_device("mps"), "cpu")
+
+    def test_select_onnx_providers_for_installed_accelerators(self):
+        available = [
+            "CoreMLExecutionProvider",
+            "OpenVINOExecutionProvider",
+            "DmlExecutionProvider",
+            "CPUExecutionProvider",
+        ]
+
+        self.assertEqual(
+            select_onnx_providers(available, device="mps"),
+            ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        )
+        self.assertEqual(
+            select_onnx_providers(available, device="xpu"),
+            ["OpenVINOExecutionProvider", "CPUExecutionProvider"],
+        )
+        self.assertEqual(
+            select_onnx_providers(available, device="directml"),
+            ["DmlExecutionProvider", "CPUExecutionProvider"],
+        )
+
+    def test_select_onnx_providers_respects_explicit_order(self):
+        available = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+        self.assertEqual(
+            select_onnx_providers(
+                available,
+                requested_providers=["CPUExecutionProvider", "CUDAExecutionProvider"],
+            ),
+            ["CPUExecutionProvider", "CUDAExecutionProvider"],
+        )
+
+    def test_select_onnx_providers_rejects_unavailable_provider(self):
+        with self.assertRaisesRegex(ValueError, "CoreMLExecutionProvider"):
+            select_onnx_providers(
+                ["CPUExecutionProvider"],
+                requested_providers=["CoreMLExecutionProvider"],
+            )
 
     def test_to_list(self):
         tts = DummyTTS()

--- a/tests/test_engine_turbo.py
+++ b/tests/test_engine_turbo.py
@@ -39,6 +39,29 @@ def test_turbo_gguf_init(mock_hf, mock_llama, mock_ort):
     assert tts.decoder_sess is not None
     mock_llama.assert_called_once()
 
+
+@patch("onnxruntime.InferenceSession")
+@patch(
+    "onnxruntime.get_available_providers",
+    return_value=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+)
+@patch("llama_cpp.Llama")
+@patch("huggingface_hub.hf_hub_download", return_value="dummy_path")
+def test_turbo_uses_requested_onnx_providers(
+    mock_hf, mock_llama, mock_available, mock_ort
+):
+    requested = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+    TurboVieNeuTTS(
+        backbone_repo="dummy",
+        device="cpu",
+        onnx_providers=requested,
+    )
+
+    assert mock_available.call_count == 2
+    assert mock_ort.call_count == 2
+    assert all(call.kwargs["providers"] == requested for call in mock_ort.call_args_list)
+
 @patch("onnxruntime.InferenceSession")
 @patch("llama_cpp.Llama")
 @patch("huggingface_hub.hf_hub_download", return_value="dummy_path")

--- a/tests/test_engine_v3turbo.py
+++ b/tests/test_engine_v3turbo.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from vieneu.v3turbo import V3TurboVieNeuTTS
+
+
+@patch.object(V3TurboVieNeuTTS, "_load_v3_voices")
+@patch("vieneu._v3_turbo_engine.onnx_runtime_lite.OnnxV3LiteEngine")
+@patch(
+    "onnxruntime.get_available_providers",
+    return_value=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+)
+def test_v3_turbo_forwards_requested_onnx_providers(
+    mock_available, mock_engine, mock_load_voices
+):
+    requested = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+    V3TurboVieNeuTTS(
+        backend="onnx",
+        device="coreml",
+        onnx_dir="dummy",
+        onnx_providers=requested,
+    )
+
+    mock_available.assert_called_once_with()
+    mock_engine.assert_called_once()
+    assert mock_engine.call_args.kwargs["providers"] == requested


### PR DESCRIPTION
## Summary

- select ONNX Runtime execution providers from the providers actually installed on the host
- support CUDA, TensorRT, ROCm/MIGraphX, OpenVINO, CoreML, DirectML, and CPU device preferences
- expose an ordered `onnx_providers` override with early validation and clear errors
- apply the resolved provider chain consistently to legacy Turbo encoder/decoder sessions and all v3 Turbo ONNX sessions, including codec, denoiser, and speaker encoder paths
- retain `CPUExecutionProvider` as the automatic fallback when it is installed

Fixes #167.

## Root cause

The Turbo paths constructed fixed CUDA/CPU or CPU-only provider lists. As a result, installing another ONNX Runtime distribution did not make its execution provider usable, and callers could not explicitly control provider order.

## Usage

```python
from vieneu import Vieneu

tts = Vieneu(
    mode="v3turbo",
    backend="onnx",
    device="coreml",
    onnx_providers=["CoreMLExecutionProvider", "CPUExecutionProvider"],
)
```

If an explicitly requested provider is not reported by `onnxruntime.get_available_providers()`, construction now fails early with the requested and available provider names.

## Validation

- `pytest -q tests/test_base_utils.py tests/test_engine_turbo.py tests/test_engine_v3turbo.py` — 15 passed
- focused Ruff check passed (excluding pre-existing findings in touched legacy modules)
- Arcade before/after: 5 components and 3 smells unchanged; the reusable provider policy adds one entity and four static edges, with A2A similarity 0.9757
