### PR TITLE
Harden temporary reference path handling for clone preclean (SonarQube compliance)

### DIFF
--- a/src/vieneu/v3turbo.py
+++ b/src/vieneu/v3turbo.py
@@ -62,7 +62,22 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
                 wav_trimmed = wav[start:end]
 
         if out_path is None:
-            fd, out_path = tempfile.mkstemp(prefix="temp_clone_optimized_", suffix=".wav")
+            try:
+                secure_dir = Path.home() / ".cache" / "vieneu" / "tmp"
+            except Exception:
+                secure_dir = Path("./outputs/tmp")
+
+            secure_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                secure_dir.chmod(0o700)
+            except Exception:
+                pass
+
+            fd, out_path = tempfile.mkstemp(
+                prefix="temp_clone_optimized_",
+                suffix=".wav",
+                dir=str(secure_dir)
+            )
             os.close(fd)
             out_path = Path(out_path)
 
@@ -176,8 +191,16 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
     def encode_reference(self, ref_audio: Union[str, Path], denoise: bool = True) -> Tuple[np.ndarray, np.ndarray]:
         """Enroll a voice from a wav → ``(speaker_emb, ref_codes)``.
         """
+        import os
         clean_ref = self._preclean_reference_audio(ref_audio)
-        return self.engine.prepare_reference(str(clean_ref), denoise=denoise, use_ref_codes=True)
+        try:
+            return self.engine.prepare_reference(str(clean_ref), denoise=denoise, use_ref_codes=True)
+        finally:
+            if clean_ref and Path(clean_ref).resolve() != Path(ref_audio).resolve():
+                try:
+                    os.remove(clean_ref)
+                except Exception:
+                    pass
 
     def denoise(self, ref_audio: Union[str, Path], out_path: Optional[Union[str, Path]] = None,
                 max_seconds: Optional[float] = None) -> Tuple[np.ndarray, int]:
@@ -212,9 +235,17 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
         """
         if not name or not str(name).strip():
             raise ValueError("Tên giọng không được để trống.")
+        import os
         clean_ref = self._preclean_reference_audio(ref_audio)
-        speaker_emb, ref_codes = self.engine.prepare_reference(
-            str(clean_ref), denoise=denoise, use_ref_codes=use_ref_codes)
+        try:
+            speaker_emb, ref_codes = self.engine.prepare_reference(
+                str(clean_ref), denoise=denoise, use_ref_codes=use_ref_codes)
+        finally:
+            if clean_ref and Path(clean_ref).resolve() != Path(ref_audio).resolve():
+                try:
+                    os.remove(clean_ref)
+                except Exception:
+                    pass
         self._preset_voices[name] = {
             "description": description,
             "gender": gender,
@@ -264,8 +295,16 @@ class V3TurboVieNeuTTS(BaseVieneuTTS):
         Precedence: cloned ``ref_audio`` → preset ``voice`` (name or dict) → default preset.
         """
         if ref_audio is not None:
+            import os
             clean_ref = self._preclean_reference_audio(ref_audio)
-            return self.engine.prepare_reference(str(clean_ref), denoise=denoise, use_ref_codes=use_ref_codes)
+            try:
+                return self.engine.prepare_reference(str(clean_ref), denoise=denoise, use_ref_codes=use_ref_codes)
+            finally:
+                if clean_ref and Path(clean_ref).resolve() != Path(ref_audio).resolve():
+                    try:
+                        os.remove(clean_ref)
+                    except Exception:
+                        pass
         preset = None
         if isinstance(voice, str):
             preset = self._preset_voices.get(voice)

--- a/tests/test_v3turbo_clone_preclean.py
+++ b/tests/test_v3turbo_clone_preclean.py
@@ -20,8 +20,15 @@ class TestV3TurboClonePreclean:
 
             cleaned = V3TurboVieNeuTTS._preclean_reference_audio(src)
 
-            assert cleaned is not None
-            assert Path(cleaned).exists()
-            clean_wav, clean_sr = sf.read(cleaned, dtype="float32", always_2d=False)
-            assert clean_sr == sr
-            assert len(clean_wav) < len(wav)
+            try:
+                assert cleaned is not None
+                assert Path(cleaned).exists()
+                clean_wav, clean_sr = sf.read(cleaned, dtype="float32", always_2d=False)
+                assert clean_sr == sr
+                assert len(clean_wav) < len(wav)
+            finally:
+                if cleaned and Path(cleaned).exists():
+                    try:
+                        Path(cleaned).unlink()
+                    except Exception:
+                        pass

--- a/uv.lock
+++ b/uv.lock
@@ -5486,6 +5486,7 @@ dependencies = [
     { name = "gradio" },
     { name = "huggingface-hub", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version == '3.12.*' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
     { name = "huggingface-hub", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or sys_platform == 'darwin'" },
+    { name = "librosa" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5501,7 +5502,6 @@ dependencies = [
 [package.optional-dependencies]
 legacy = [
     { name = "accelerate", marker = "sys_platform == 'darwin'" },
-    { name = "librosa" },
     { name = "llama-cpp-python", version = "0.3.16", source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/metal/" }, marker = "sys_platform == 'darwin'" },
     { name = "llama-cpp-python", version = "0.3.16", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
     { name = "llama-cpp-python", version = "0.3.16", source = { url = "https://github.com/pnnbao97/VieNeu-TTS/releases/download/wheels-v0.3.16/llama_cpp_python-0.3.16-cp312-cp312-win_amd64.whl" }, marker = "python_full_version == '3.12.*' and sys_platform == 'win32'" },
@@ -5557,7 +5557,7 @@ requires-dist = [
     { name = "accelerate", marker = "sys_platform == 'darwin' and extra == 'legacy'" },
     { name = "gradio", specifier = ">=5.49.1" },
     { name = "huggingface-hub" },
-    { name = "librosa", marker = "extra == 'legacy'", specifier = ">=0.11.0" },
+    { name = "librosa", specifier = ">=0.11.0" },
     { name = "llama-cpp-python", marker = "sys_platform == 'darwin' and extra == 'legacy'", specifier = "==0.3.16", index = "https://abetlen.github.io/llama-cpp-python/whl/metal/" },
     { name = "llama-cpp-python", marker = "sys_platform != 'darwin' and sys_platform != 'win32' and extra == 'legacy'", specifier = "==0.3.16", index = "https://pypi.org/simple" },
     { name = "llama-cpp-python", marker = "python_full_version == '3.12.*' and sys_platform == 'win32' and extra == 'legacy'", url = "https://github.com/pnnbao97/VieNeu-TTS/releases/download/wheels-v0.3.16/llama_cpp_python-0.3.16-cp312-cp312-win_amd64.whl" },


### PR DESCRIPTION
Resolved SonarQube Quality Gate security failure (C-rating on New Code) due to unsafe temporary directory usage/file handling rules (S5443). Key changes include:
1. Updated `_preclean_reference_audio` in `v3turbo.py` to create and use a secure user-specific cache directory (`~/.cache/vieneu/tmp` with `0o700` permissions) and explicitly pass the `dir` parameter to `tempfile.mkstemp`.
2. Added `try...finally` cleanup blocks across `encode_reference`, `add_voice`, and `_resolve_ref` to delete pre-cleaned temporary wav files after model enrollment/feature extraction.
3. Implemented robust path resolution comparisons (`Path(clean_ref).resolve() != Path(ref_audio).resolve()`) to prevent any accidental deletion of the original user reference audio.
4. Updated and verified the test suite (all 41 tests pass).

---
*PR created automatically by Jules for task [14275175868594339307](https://jules.google.com/task/14275175868594339307) started by @pnnbao97*