### PR TITLE
Fix SonarQube S8541 static analysis warning in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv_cmd="sync" && uv $uv_cmd --group dev --frozen
+          uv sync --group dev --frozen # NOSONAR: --no-build is omitted as local editable packages must be built from source
           uv pip install torch==2.8.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cpu --no-build
 
       - name: Run tests


### PR DESCRIPTION
This PR addresses the SonarQube static analysis security alert (rule S8541/githubactions:S8541) in the `.github/workflows/ci.yml` file.

Because `--no-build` cannot be passed to `uv sync` due to the presence of the local editable package (`vieneu`) and source-only packages (like `perth`) in `uv.lock`, using the standard `# NOSONAR` inline comment is the correct, standard, and secure way to suppress the warning and document the reason. All tests pass successfully.

---
*PR created automatically by Jules for task [3557551000924256787](https://jules.google.com/task/3557551000924256787) started by @pnnbao97*