### PR TITLE
fix(core_utils): syllable_count đếm thiếu âm tiết của từ tiếng Anh

### DIFF
--- a/src/vieneu_utils/core_utils.py
+++ b/src/vieneu_utils/core_utils.py
@@ -714,7 +714,11 @@ BABBLE_MAX_RETRIES = 2
 _BURST_THRESH_DB = -18.0       # cụm = RMS trên ngưỡng này so với RMS đỉnh (hơi thở ~ -25 dB không tính)
 _BURST_MIN_GAP_MS = 60         # hai cụm cách nhau dưới mức này là một cụm (phụ âm đầu bật hơi)
 _BURST_MIN_MS = 30
-_IPA_VOWELS = set("aeiouyæɐɑɒɔəɘɛɜɤɯɵøœʉʊʌɪɨ")
+# ɚ ɝ  nguyên âm r-colored (computer, fire, hour, bird — giọng Mỹ)
+# ᵻ ᵿ  nguyên âm giảm eSpeak dùng cho âm tiết không nhấn (director -> dᵻɹˈɛktɚ)
+# Thiếu bốn ký hiệu này thì cả một âm tiết biến mất khỏi phép đếm. Tiếng Việt
+# không dùng ký hiệu nào trong số đó nên bổ sung không đụng tới tiếng Việt.
+_IPA_VOWELS = set("aeiouyæɐɑɒɔəɘɛɜɤɯɵøœʉʊʌɪɨɚɝᵻᵿ")
 
 
 def syllable_count(phonemes: str) -> int:
@@ -736,7 +740,19 @@ def syllable_count(phonemes: str) -> int:
                     groups += 1
                 in_v, consonant_seen = True, False
             elif ch in "ːˈˌ" or ch.isdigit():
-                in_v = False
+                # Dấu nhấn đứng TRƯỚC âm tiết mà nó nhấn, nên một dấu nhấn xuất
+                # hiện SAU khi token đã có cụm nguyên âm là ranh giới âm tiết —
+                # kể cả khi không có phụ âm nào chen giữa:
+                #   kɹiːˈeɪt (create)   iː | ˈeɪ        -> 2, trước đây đếm 1
+                #   kəmpjˈuːɾɚ          ə | ˈuː | ɾɚ    -> 3, trước đây đếm 2
+                #   ɹˈeɪdɪˌoʊ (radio)   ˈeɪ | dɪ | ˌoʊ  -> 3, trước đây đếm 2
+                # Điều kiện groups > 0 giữ tiếng Việt nguyên vẹn: sea-g2p đặt
+                # đúng MỘT dấu nhấn cho mỗi tiếng và luôn TRƯỚC cụm nguyên âm
+                # đầu tiên (bˈaːɜw, kwˈaːɜ), lúc đó groups vẫn bằng 0.
+                if ch in "ˈˌ" and groups > 0:
+                    in_v, consonant_seen = False, True
+                else:
+                    in_v = False
             else:
                 in_v, consonant_seen = False, True
         if any(ch.isalpha() for ch in tok):


### PR DESCRIPTION
# fix(core_utils): `syllable_count` đếm thiếu âm tiết của từ tiếng Anh

## Vấn đề

`syllable_count` bỏ sót âm tiết ở một số từ tiếng Anh, làm
`max_expected_frames` trả trần thấp hơn thực tế và chunk bị cắt cụt.

Đo trên 44 từ tiếng Anh, phoneme lấy từ `SEAPipeline(lang="vi").run(...)`
(sea-g2p 0.9.1) — **13 từ bị đếm thiếu**, ví dụ:

| từ | phoneme | đếm được | thật | trần frame |
|---|---|---|---|---|
| `create` | `kɹiːˈeɪt` | 1 | 2 | 13 (1,04 s) |
| `director` | `dᵻɹˈɛktɚ` | 1 | 3 | 13 (1,04 s) |
| `computer` | `kəmpjˈuːɾɚ` | 2 | 3 | 18 |
| `radio` | `ɹˈeɪdɪˌoʊ` | 2 | 3 | 18 |
| `audio` | `ˈɔːdɪˌoʊ` | 2 | 3 | 18 |
| `register` / `customer` / `energy` / `api` | | 2 | 3 | 18 |

## Hai nguyên nhân

**1. `_IPA_VOWELS` thiếu bốn ký hiệu** mà eSpeak/sea-g2p vẫn sinh ra:
`ɚ ɝ` (nguyên âm r-colored: `computer`, `fire`, `hour`, `bird`) và
`ᵻ ᵿ` (nguyên âm giảm ở âm tiết không nhấn: `director` → `dᵻɹˈɛktɚ`).
Thiếu chúng thì cả một âm tiết biến mất khỏi phép đếm.

**2. Nhóm nguyên âm mới chỉ mở sau một PHỤ ÂM.** Nhưng trong IPA, dấu nhấn
đứng ngay trước âm tiết mà nó nhấn, nên dấu nhấn cũng là ranh giới âm tiết —
kể cả khi không có phụ âm chen giữa:

```
kɹiːˈeɪt   (create)  iː | ˈeɪ         -> 2, code cũ đếm 1
kəmpjˈuːɾɚ (computer) ə | ˈuː | ɾɚ    -> 3, code cũ đếm 2
ɹˈeɪdɪˌoʊ  (radio)   ˈeɪ | dɪ | ˌoʊ   -> 3, code cũ đếm 2
```

## Bản vá

Thêm bốn nguyên âm, và cho `ˈ`/`ˌ` mở âm tiết mới **khi token đã có ít nhất một
cụm nguyên âm** (`groups > 0`).

Điều kiện `groups > 0` là chỗ giữ an toàn cho tiếng Việt: sea-g2p đặt đúng MỘT
dấu nhấn cho mỗi tiếng và luôn TRƯỚC cụm nguyên âm đầu tiên (`bˈaːɜw`,
`kwˈaːɜ`, `t̪wˈiɛ6t̪`), nên lúc đó `groups` vẫn bằng 0 và nhánh mới không bao
giờ chạy.

## Nghiệm thu

- **Tiếng Anh (44 ca):** sửa được 9, không làm hỏng ca nào.
- **Tiếng Việt (49 ca):** 0 thay đổi. Bộ đối chứng phủ nguyên âm đôi/ba và đủ 6
  thanh — `khuya`, `yêu`, `chuyên`, `tuyệt`, `người`, `buổi`, `quyển`, `thuyền`,
  `ngoại`, `nghiêng`, `ruộng`, `quốc`, `hươu`, `rượu`, `nguyễn`, …

## Còn lại (cố ý không vá)

4 ca vẫn đếm thiếu 1: `video` (`vˈɪdɪoʊ`), `area` (`ˈɛɹiə`), `idea` (`aɪdˈiə`),
`premium` (`pɹˈiːmiəm`) — hiatus không có dấu nhấn ngăn giữa.

Không vá được an toàn bằng luật thuần phoneme: `iə` của tiếng Anh trùng đúng
`iə` của `khuya` (`xwˈiə`) trong tiếng Việt. Tách nó sẽ đếm nguyên âm đôi tiếng
Việt thành hai tiếng. Đếm thiếu ở đây chỉ hạ trần từ 23 xuống 18 frame, nhẹ hơn
nhiều so với hồi quy tiếng Việt, nên để nguyên.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)